### PR TITLE
Fix endpoint URL for CreatePendingLineItem call

### DIFF
--- a/customer.go
+++ b/customer.go
@@ -303,7 +303,7 @@ func (c *Customer) DeleteContact(contactID int64) error {
 
 func (c *Customer) CreatePendingLineItem(pendingLineItem *invdendpoint.PendingLineItem) (*invdendpoint.PendingLineItem, error) {
 
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items "
+	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items"
 
 	pendingLineItemResp := new(invdendpoint.PendingLineItem)
 


### PR DESCRIPTION
An extra space was causing this call to fail e.g. "POST /customers/123456/line_items%20"