### PR TITLE
Export MockConnection

### DIFF
--- a/customer_test.go
+++ b/customer_test.go
@@ -2,12 +2,13 @@ package invdapi
 
 import (
 	"encoding/json"
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 type customerMetaData map[string]interface{}
@@ -52,7 +53,7 @@ func TestCustomerCreate(t *testing.T) {
 
 	//Establish our mock connection
 	key := "test api key"
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customer := conn.NewCustomer()
 
@@ -94,7 +95,7 @@ func TestCustomerCreateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	custConn := conn.NewCustomer()
 
@@ -132,7 +133,7 @@ func TestCustomerUpdate(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customerToUpdate := conn.NewCustomer()
 
@@ -169,7 +170,7 @@ func TestCustomerUpdateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customer := conn.NewCustomer()
 	customer.Name = "Parag Patel"
@@ -203,7 +204,7 @@ func TestCustomerDelete(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customer := conn.NewCustomer()
 
@@ -234,7 +235,7 @@ func TestCustomerDeleteError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customer := conn.NewCustomer()
 
@@ -277,7 +278,7 @@ func TestCustomerList(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customer := conn.NewCustomer()
 
@@ -311,7 +312,7 @@ func TestCustomerListError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	customer := conn.NewCustomer()
 

--- a/customer_test.go
+++ b/customer_test.go
@@ -2,13 +2,12 @@ package invdapi
 
 import (
 	"encoding/json"
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 type customerMetaData map[string]interface{}

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -1,12 +1,13 @@
 package invdapi
 
 import (
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 func TestInvoiceCreate(t *testing.T) {
@@ -26,7 +27,7 @@ func TestInvoiceCreate(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoice := conn.NewInvoice()
 
@@ -62,7 +63,7 @@ func TestInvoiceCreateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoice := conn.NewInvoice()
 
@@ -101,7 +102,7 @@ func TestInvoiceUpdate(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoiceToUpdate := conn.NewInvoice()
 	invoiceToUpdate.Balance = 42.22
@@ -133,7 +134,7 @@ func TestInvoiceUpdateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoiceToUpdate := conn.NewInvoice()
 
@@ -166,7 +167,7 @@ func TestInvoiceDelete(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoice := conn.NewInvoice()
 
@@ -195,7 +196,7 @@ func TestInvoiceDeleteError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoice := conn.NewInvoice()
 
@@ -235,7 +236,7 @@ func TestInvoiceList(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoice := conn.NewInvoice()
 
@@ -268,7 +269,7 @@ func TestInvoiceListError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	invoice := conn.NewInvoice()
 

--- a/invoice_test.go
+++ b/invoice_test.go
@@ -1,13 +1,12 @@
 package invdapi
 
 import (
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
-
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 func TestInvoiceCreate(t *testing.T) {

--- a/mockconnection.go
+++ b/mockconnection.go
@@ -6,7 +6,29 @@ import (
 	"net/http/httptest"
 )
 
-func mockConnection(key string, server *httptest.Server) *Connection {
+// MockConnection is helpful when writing tests for
+// functions that use an Invoice connection to interact
+// with the Invoice API. It requires an arbitrary string
+// as its key parameter and an initialized http server.
+//
+// Example (error checking omitted):
+//	key := "test api key"
+// 	mockInvoiceResponse := new(invdendpoint.Invoice)
+// 	mockInvoiceResponse.Id = int64(12345)
+// 	server, _ := invdmockserver.New(200, mockInvoiceResponse, "json", true)
+// 	conn := MockConnection(key, server)
+// 	invoice := conn.NewInvoice()
+//
+// Make sure that if you have rules that prune `unused-packages`,
+// you make an exception for this project in order to get the
+// rest of the requirements for mocking this codebase.
+// 	[prune]
+// 		unused-packages = true
+// 		[[prune.project]]
+// 			name = "github.com/Invoiced/invoiced-go"
+// 			unused-packages = false
+
+func MockConnection(key string, server *httptest.Server) *Connection {
 	c := new(Connection)
 	c.key = key
 

--- a/mockconnection_test.go
+++ b/mockconnection_test.go
@@ -19,7 +19,7 @@ func TestMockConnection(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection("whatever", server)
+	conn := MockConnection("whatever", server)
 	customerToCreate.Connection = conn
 
 	customer := conn.NewCustomer()

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -1,12 +1,11 @@
 package invdapi
 
 import (
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 func TestSubscriptionCreate(t *testing.T) {

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -1,11 +1,12 @@
 package invdapi
 
 import (
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 func TestSubscriptionCreate(t *testing.T) {
@@ -26,7 +27,7 @@ func TestSubscriptionCreate(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	subscription := conn.NewSubscription()
 
@@ -62,7 +63,7 @@ func TestSubscriptionCreateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	subscription := conn.NewSubscription()
 	subscriptionToCreate := subscription.NewSubscription()
 	subscriptionToCreate.Customer = 234112
@@ -96,7 +97,7 @@ func TestSubscriptionUpdate(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	subscriptionToUpdate := conn.NewSubscription()
 
@@ -130,7 +131,7 @@ func TestSubscriptionUpdateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	subcriptionToUpdate := conn.NewSubscription()
 
 	subcriptionToUpdate.Cycles = 42
@@ -162,7 +163,7 @@ func TestSubscriptionDelete(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	subscription := conn.NewSubscription()
 
@@ -193,7 +194,7 @@ func TestSubscriptionDeleteError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	subscription := conn.NewSubscription()
 
@@ -225,7 +226,7 @@ func TestSubscriptionRetrieve(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	subscription := conn.NewSubscription()
 
 	retrievedSubscription, err := subscription.Retrieve(mockSubscriptionResponseID)
@@ -256,7 +257,7 @@ func TestSubscriptionRetrieveError(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	subscription := conn.NewSubscription()
 
 	_, err = subscription.Retrieve(mockSubscriptionID)

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -1,12 +1,11 @@
 package invdapi
 
 import (
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"testing"
 	"time"
-
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 func TestTransactionCreate(t *testing.T) {

--- a/transactions_test.go
+++ b/transactions_test.go
@@ -1,11 +1,12 @@
 package invdapi
 
 import (
-	"github.com/Invoiced/invoiced-go/invdendpoint"
-	"github.com/Invoiced/invoiced-go/invdmockserver"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/Invoiced/invoiced-go/invdendpoint"
+	"github.com/Invoiced/invoiced-go/invdmockserver"
 )
 
 func TestTransactionCreate(t *testing.T) {
@@ -26,7 +27,7 @@ func TestTransactionCreate(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	transaction := conn.NewTransaction()
 
@@ -62,7 +63,7 @@ func TestTransactionCreateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	transaction := conn.NewTransaction()
 	transactionToCreate := transaction.NewTransaction()
 	transactionToCreate.Customer = 234112
@@ -96,7 +97,7 @@ func TestTransactionUpdate(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	transactionToUpdate := conn.NewTransaction()
 
@@ -130,7 +131,7 @@ func TestTransactionUpdateError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	subcriptionToUpdate := conn.NewTransaction()
 
 	subcriptionToUpdate.Amount = 42
@@ -162,7 +163,7 @@ func TestTransactionDelete(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	transaction := conn.NewTransaction()
 
@@ -193,7 +194,7 @@ func TestTransactionDeleteError(t *testing.T) {
 
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 
 	transaction := conn.NewTransaction()
 
@@ -225,7 +226,7 @@ func TestTransactionRetrieve(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	transaction := conn.NewTransaction()
 
 	retrievedTransaction, err := transaction.Retrieve(mockTransactionResponseID)
@@ -256,7 +257,7 @@ func TestTransactionRetrieveError(t *testing.T) {
 	}
 	defer server.Close()
 
-	conn := mockConnection(key, server)
+	conn := MockConnection(key, server)
 	transaction := conn.NewTransaction()
 
 	_, err = transaction.Retrieve(mockTransactionID)


### PR DESCRIPTION
Prior to this commit, projects that used this library we're unable to
take advantage of the mocking infrastructure that exists! This lead to
challenges when trying to test functions that used an
*invdapi.Connection for instance.

This commit remedies that challenge by revising the unexported `mockConnection`
function to an exported `MockConnection`. It also adds some
documentation to help anyone interested in _how_ to use the mocked
connection and how to access it in their own project. Further, it
revises all the calls that existed to the unexported function to use the
exported name.

Thanks for taking a look!

Closes #7

~(It also appears that gofmt voiced it's opinion about the order of some of the imports when I saved this files 🙃)~