### PR TITLE
Add Plan field to SubscriptionAddon struct

### DIFF
--- a/invdendpoint/subscriptionaddons.go
+++ b/invdendpoint/subscriptionaddons.go
@@ -3,6 +3,7 @@ package invdendpoint
 type SubscriptionAddon struct {
 	Id          int64       `json:"id,omitempty"`           //The subscription’s unique ID
 	CatalogItem CatalogItem `json:"catalog_item,omitempty"` //Catalog Item ID
+	Plan        string      `json:"plan,omitempty"`         //The Subscription's Plan ID
 	Quantity    int64       `json:"quantity,omitempty"`     //Quantity
 	CreatedAt   int64       `json:"created_at,omitempty"`   //Timestamp when created
 }

--- a/invdendpoint/subscriptionaddons_test.go
+++ b/invdendpoint/subscriptionaddons_test.go
@@ -23,6 +23,7 @@ func TestUnMarshalSubscriptionAddonObject(t *testing.T) {
   "created_at": 1477327516,
   "metadata": {}
 },
+    "plan" : "test-plan",
     "quantity": 11,
     "created_at": 1420391704
 }`


### PR DESCRIPTION
The Invoiced API docs detail a 'plan' field in the Subscription
AddOn Object but, at the time of this commit, this library does not
include it in its own SubscriptionAddon struct. This lead to
difficulty using plans with subscriptions addons.

After this commit, there will be a 'Plan' field exposed so that users
can specify an addon's plan.