### PR TITLE
Revise SubscriptionAddon's CatalogItem field

### DIFF
--- a/invdendpoint/subscriptionaddons.go
+++ b/invdendpoint/subscriptionaddons.go
@@ -1,9 +1,9 @@
 package invdendpoint
 
 type SubscriptionAddon struct {
-	Id          int64       `json:"id,omitempty"`           //The subscription’s unique ID
-	CatalogItem CatalogItem `json:"catalog_item,omitempty"` //Catalog Item ID
-	Plan        string      `json:"plan,omitempty"`         //The Subscription's Plan ID
-	Quantity    int64       `json:"quantity,omitempty"`     //Quantity
-	CreatedAt   int64       `json:"created_at,omitempty"`   //Timestamp when created
+	Id          int64  `json:"id,omitempty"`           //The subscription’s unique ID
+	CatalogItem string `json:"catalog_item,omitempty"` //Catalog Item ID
+	Plan        string `json:"plan,omitempty"`         //The Subscription's Plan ID
+	Quantity    int64  `json:"quantity,omitempty"`     //Quantity
+	CreatedAt   int64  `json:"created_at,omitempty"`   //Timestamp when created
 }

--- a/invdendpoint/subscriptionaddons_test.go
+++ b/invdendpoint/subscriptionaddons_test.go
@@ -8,21 +8,7 @@ import (
 func TestUnMarshalSubscriptionAddonObject(t *testing.T) {
 	s := `{
     "id": 3,
-    "catalog_item": {
-  "id": "delivery",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+    "catalog_item": "delivery",
     "plan" : "test-plan",
     "quantity": 11,
     "created_at": 1420391704

--- a/invdendpoint/subscriptions_test.go
+++ b/invdendpoint/subscriptions_test.go
@@ -19,21 +19,7 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
     "addons": [
         {
             "id": 3,
-            "catalog_item": {
-  "id": "ipad-license",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+            "catalog_item": "ipad-license"
             "quantity": 11,
             "created_at": 1420391704
         }


### PR DESCRIPTION
Prior to this commit, attempting to use a CatalogItem as a
SubscriptionAddon resulted in this error:

```
json: cannot unmarshal bool into Go struct field SubscriptionAddon.id of type int64
```

This lead to what seemed like an inability to actually use catalog items
as subscription addons.

This commit revises the CatalogItem field of the SubscriptionAddon
structure. It has been converted from it's own struct to a string.

While the catalog item field within a subscription addon appears to be
undocumented, the documentation around catalog items in the API suggests
that strings are expected.

The revisions in this commit have allowed me to use catalog items as
subscription addons as I'd expected.

Thanks for taking a look, and feel free to let me know if I was just
using it all wrong!