### PR TITLE
Export makeEndPointURL function

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -187,7 +187,7 @@ func makeEndPointSingular(endpoint string, id int64) string {
 	return endpoint + "/" + strconv.FormatInt(id, 10)
 }
 
-func (c *Connection) makeEndPointURL(endPoint string) string {
+func (c *Connection) MakeEndPointURL(endPoint string) string {
 
 	return c.url + endPoint
 }

--- a/customer.go
+++ b/customer.go
@@ -20,7 +20,7 @@ func (c *Connection) NewCustomer() *Customer {
 }
 
 func (c *Customer) Count() (int64, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.CustomersEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.CustomersEndPoint)
 
 	count, apiErr := c.count(endPoint)
 
@@ -33,7 +33,7 @@ func (c *Customer) Count() (int64, error) {
 }
 
 func (c *Customer) Create(customer *Customer) (*Customer, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.CustomersEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.CustomersEndPoint)
 	custResp := new(Customer)
 
 	apiErr := c.create(endPoint, customer, custResp)
@@ -49,7 +49,7 @@ func (c *Customer) Create(customer *Customer) (*Customer, error) {
 }
 
 func (c *Customer) Delete() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
 
 	apiErr := c.delete(endPoint)
 
@@ -62,7 +62,7 @@ func (c *Customer) Delete() error {
 }
 
 func (c *Customer) Save() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
 	custResp := new(Customer)
 	apiErr := c.update(endPoint, c, custResp)
 
@@ -77,7 +77,7 @@ func (c *Customer) Save() error {
 }
 
 func (c *Customer) Retrieve(id int64) (*Customer, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), id)
 
 	custEndPoint := new(invdendpoint.Customer)
 
@@ -94,7 +94,7 @@ func (c *Customer) Retrieve(id int64) (*Customer, error) {
 }
 
 func (c *Customer) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Customers, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.CustomersEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.CustomersEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	customers := make(Customers, 0)
@@ -124,7 +124,7 @@ NEXT:
 }
 
 func (c *Customer) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Customers, string, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.CustomersEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.CustomersEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	customers := make(Customers, 0)
@@ -188,7 +188,7 @@ func (c *Customer) ListCustomerByNumber(customerNumber string) (*Customer, error
 }
 
 func (c *Customer) GetBalance() (*invdendpoint.CustomerBalance, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/balance"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/balance"
 
 	custBalance := new(invdendpoint.CustomerBalance)
 
@@ -202,7 +202,7 @@ func (c *Customer) GetBalance() (*invdendpoint.CustomerBalance, error) {
 }
 
 func (c *Customer) SendStatement(custStmtReq *invdendpoint.EmailResponse) (*invdendpoint.EmailResponses, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/emails"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/emails"
 
 	custStmtResp := new(invdendpoint.EmailResponses)
 	err := c.create(endPoint, custStmtReq, custStmtResp)
@@ -215,7 +215,7 @@ func (c *Customer) SendStatement(custStmtReq *invdendpoint.EmailResponse) (*invd
 }
 
 func (c *Customer) CreateContact(contact *invdendpoint.Contact) (*invdendpoint.Contact, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts"
 
 	createdContact := new(invdendpoint.Contact)
 
@@ -230,7 +230,7 @@ func (c *Customer) CreateContact(contact *invdendpoint.Contact) (*invdendpoint.C
 }
 
 func (c *Customer) RetrieveContact(contactID int64) (*invdendpoint.Contact, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts" + strconv.FormatInt(contactID, 10)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts" + strconv.FormatInt(contactID, 10)
 
 	retrievedContact := new(invdendpoint.Contact)
 
@@ -250,7 +250,7 @@ func (c *Customer) UpdateContact(contactToUpdate *invdendpoint.Contact) (*invden
 		return nil, errors.New("Need to supply a contact id in order to update a contact")
 	}
 
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts" + strconv.FormatInt(contactToUpdate.Id, 10)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts" + strconv.FormatInt(contactToUpdate.Id, 10)
 
 	contResp := new(invdendpoint.Contact)
 	err := c.update(endPoint, contactToUpdate, contResp)
@@ -264,7 +264,7 @@ func (c *Customer) UpdateContact(contactToUpdate *invdendpoint.Contact) (*invden
 }
 
 func (c *Customer) ListAllContacts() (invdendpoint.Contacts, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts"
 
 	contacts := make(invdendpoint.Contacts, 0)
 
@@ -289,7 +289,7 @@ NEXT:
 
 func (c *Customer) DeleteContact(contactID int64) error {
 
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts" + strconv.FormatInt(contactID, 10)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/contacts" + strconv.FormatInt(contactID, 10)
 
 	err := c.delete(endPoint)
 
@@ -303,7 +303,7 @@ func (c *Customer) DeleteContact(contactID int64) error {
 
 func (c *Customer) CreatePendingLineItem(pendingLineItem *invdendpoint.PendingLineItem) (*invdendpoint.PendingLineItem, error) {
 
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items"
 
 	pendingLineItemResp := new(invdendpoint.PendingLineItem)
 
@@ -319,7 +319,7 @@ func (c *Customer) CreatePendingLineItem(pendingLineItem *invdendpoint.PendingLi
 
 func (c *Customer) RetrievePendingLineItem(id int64) (*invdendpoint.PendingLineItem, error) {
 
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items" + strconv.FormatInt(id, 10)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items" + strconv.FormatInt(id, 10)
 
 	retrievedPendingLineItem := new(invdendpoint.PendingLineItem)
 
@@ -339,7 +339,7 @@ func (c *Customer) UpdatePendingLineItem(pendingLineItem *invdendpoint.PendingLi
 		return nil, errors.New("Need to supply a pending line item id in order to update a pending line item")
 	}
 
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items" + strconv.FormatInt(pendingLineItem.Id, 10)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/line_items" + strconv.FormatInt(pendingLineItem.Id, 10)
 
 	pendingLineItemResp := new(invdendpoint.PendingLineItem)
 	err := c.update(endPoint, pendingLineItem, pendingLineItemResp)
@@ -353,7 +353,7 @@ func (c *Customer) UpdatePendingLineItem(pendingLineItem *invdendpoint.PendingLi
 }
 
 func (c *Customer) TriggerInvoice() (*Invoice, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/invoices"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id) + "/invoices"
 
 	invoice := new(Invoice)
 
@@ -370,7 +370,7 @@ func (c *Customer) TriggerInvoice() (*Invoice, error) {
 }
 
 func (c *Customer) DeletePendingLineItem(id int64) error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.CustomersEndPoint), c.Id)
 
 	err := c.delete(endPoint)
 

--- a/event.go
+++ b/event.go
@@ -18,7 +18,7 @@ func (c *Connection) NewEvent() *Event {
 }
 
 func (c *Event) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Events, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.EventsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.EventsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	events := make(Events, 0)
@@ -48,7 +48,7 @@ NEXT:
 }
 
 func (c *Event) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Events, string, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.EventsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.EventsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	events := make(Events, 0)

--- a/file.go
+++ b/file.go
@@ -18,7 +18,7 @@ func (c *Connection) NewFile() *File {
 }
 
 func (c *File) Create(file *File) (*File, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.FilesEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.FilesEndPoint)
 	fileResp := new(File)
 
 	apiErr := c.create(endPoint, file, fileResp)
@@ -34,7 +34,7 @@ func (c *File) Create(file *File) (*File, error) {
 }
 
 func (c *File) Delete() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.FilesEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.FilesEndPoint), c.Id)
 
 	err := c.delete(endPoint)
 
@@ -47,7 +47,7 @@ func (c *File) Delete() error {
 }
 
 func (c *File) Retrieve(id int64) (*File, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.FilesEndPoint), id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.FilesEndPoint), id)
 
 	custEndPoint := new(invdendpoint.File)
 

--- a/invoice.go
+++ b/invoice.go
@@ -22,7 +22,7 @@ func (c *Connection) NewInvoice() *Invoice {
 }
 
 func (c *Invoice) Count() (int64, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.InvoicesEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.InvoicesEndPoint)
 
 	count, apiErr := c.count(endPoint)
 
@@ -35,7 +35,7 @@ func (c *Invoice) Count() (int64, error) {
 }
 
 func (c *Invoice) Create(invoice *Invoice) (*Invoice, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.InvoicesEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.InvoicesEndPoint)
 	invResp := new(Invoice)
 
 	apiErr := c.create(endPoint, invoice, invResp)
@@ -51,7 +51,7 @@ func (c *Invoice) Create(invoice *Invoice) (*Invoice, error) {
 }
 
 func (c *Invoice) Delete() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id)
 
 	apiErr := c.delete(endPoint)
 
@@ -64,7 +64,7 @@ func (c *Invoice) Delete() error {
 }
 
 func (c *Invoice) Save() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id)
 	invResp := new(Invoice)
 	apiErr := c.update(endPoint, c, invResp)
 
@@ -79,7 +79,7 @@ func (c *Invoice) Save() error {
 }
 
 func (c *Invoice) Retrieve(id int64) (*Invoice, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), id)
 
 	if c.IncludeUpdatedAt {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
@@ -106,7 +106,7 @@ func (c *Invoice) Retrieve(id int64) (*Invoice, error) {
 }
 
 func (c *Invoice) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Invoices, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.InvoicesEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.InvoicesEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	if c.IncludeUpdatedAt {
@@ -146,7 +146,7 @@ NEXT:
 }
 
 func (c *Invoice) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Invoices, string, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.InvoicesEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.InvoicesEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 	if c.IncludeUpdatedAt {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
@@ -199,7 +199,7 @@ func (c *Invoice) ListInvoiceByNumber(invoiceNumber string) (*Invoice, error) {
 }
 
 func (c *Invoice) Send(emailReq *invdendpoint.EmailRequest) (invdendpoint.EmailResponses, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/emails"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/emails"
 
 	emailResp := new(invdendpoint.EmailResponses)
 
@@ -214,7 +214,7 @@ func (c *Invoice) Send(emailReq *invdendpoint.EmailRequest) (invdendpoint.EmailR
 }
 
 func (c *Invoice) Pay() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/pay"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/pay"
 	invoice := new(invdendpoint.Invoice)
 	err := c.create(endPoint, nil, invoice)
 
@@ -229,7 +229,7 @@ func (c *Invoice) Pay() error {
 }
 
 func (c *Invoice) ListAttachements() (Files, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/attachments"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/attachments"
 	files := make(Files, 0)
 	err := c.create(endPoint, nil, files)
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -20,7 +20,7 @@ func (c *Connection) NewSubscription() *Subscription {
 }
 
 func (c *Subscription) Count() (int64, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 
 	count, apiErr := c.count(endPoint)
 
@@ -33,7 +33,7 @@ func (c *Subscription) Count() (int64, error) {
 }
 
 func (c *Subscription) Create(subscription *Subscription) (*Subscription, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	subResp := new(Subscription)
 
 	apiErr := c.create(endPoint, subscription, subResp)
@@ -49,7 +49,7 @@ func (c *Subscription) Create(subscription *Subscription) (*Subscription, error)
 }
 
 func (c *Subscription) Cancel() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint), c.Id)
 
 	apiErr := c.delete(endPoint)
 
@@ -62,7 +62,7 @@ func (c *Subscription) Cancel() error {
 }
 
 func (c *Subscription) Save() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint), c.Id)
 	subResp := new(Subscription)
 	apiErr := c.update(endPoint, c, subResp)
 
@@ -77,7 +77,7 @@ func (c *Subscription) Save() error {
 }
 
 func (c *Subscription) Retrieve(id int64) (*Subscription, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint), id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint), id)
 
 	expandedValues := invdendpoint.NewExpand()
 
@@ -100,7 +100,7 @@ func (c *Subscription) Retrieve(id int64) (*Subscription, error) {
 }
 
 func (c *Subscription) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Subscriptions, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	expandedValues := invdendpoint.NewExpand()
@@ -136,7 +136,7 @@ NEXT:
 }
 
 func (c *Subscription) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Subscriptions, string, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.SubscriptionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	expandedValues := invdendpoint.NewExpand()

--- a/transactions.go
+++ b/transactions.go
@@ -31,7 +31,7 @@ func (c *Connection) NewTransaction() *Transaction {
 }
 
 func (c *Transaction) Count() (int64, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.TransactionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.TransactionsEndPoint)
 
 	count, apiErr := c.count(endPoint)
 
@@ -44,7 +44,7 @@ func (c *Transaction) Count() (int64, error) {
 }
 
 func (c *Transaction) Create(transaction *Transaction) (*Transaction, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.TransactionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.TransactionsEndPoint)
 	txnResp := new(Transaction)
 
 	apiErr := c.create(endPoint, transaction, txnResp)
@@ -60,7 +60,7 @@ func (c *Transaction) Create(transaction *Transaction) (*Transaction, error) {
 }
 
 func (c *Transaction) Delete() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.TransactionsEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.TransactionsEndPoint), c.Id)
 
 	apiErr := c.delete(endPoint)
 
@@ -73,7 +73,7 @@ func (c *Transaction) Delete() error {
 }
 
 func (c *Transaction) Save() error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.TransactionsEndPoint), c.Id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.TransactionsEndPoint), c.Id)
 	txnResp := new(Transaction)
 	apiErr := c.update(endPoint, c, txnResp)
 
@@ -88,7 +88,7 @@ func (c *Transaction) Save() error {
 }
 
 func (c *Transaction) Retrieve(id int64) (*Transaction, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.TransactionsEndPoint), id)
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.TransactionsEndPoint), id)
 
 	custEndPoint := new(invdendpoint.Transaction)
 
@@ -105,7 +105,7 @@ func (c *Transaction) Retrieve(id int64) (*Transaction, error) {
 }
 
 func (c *Transaction) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Transactions, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.TransactionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.TransactionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	transactions := make(Transactions, 0)
@@ -135,7 +135,7 @@ NEXT:
 }
 
 func (c *Transaction) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Transactions, string, error) {
-	endPoint := c.makeEndPointURL(invdendpoint.TransactionsEndPoint)
+	endPoint := c.MakeEndPointURL(invdendpoint.TransactionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
 
 	transactions := make(Transactions, 0)
@@ -312,7 +312,7 @@ func (c *Transaction) ListSuccessfulChargesAndPaymentsByInvoiceID(invoiceID int6
 }
 
 func (c *Transaction) SendReceipt(emailReq *invdendpoint.EmailRequest) (invdendpoint.EmailResponses, error) {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/emails"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.InvoicesEndPoint), c.Id) + "/emails"
 
 	emailResp := new(invdendpoint.EmailResponses)
 
@@ -327,7 +327,7 @@ func (c *Transaction) SendReceipt(emailReq *invdendpoint.EmailRequest) (invdendp
 }
 
 func (c *Transaction) Refund(refund *invdendpoint.Refund) error {
-	endPoint := makeEndPointSingular(c.makeEndPointURL(invdendpoint.TransactionsEndPoint), c.Id) + "/refunds"
+	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.TransactionsEndPoint), c.Id) + "/refunds"
 	transaction := new(invdendpoint.Transaction)
 	err := c.create(endPoint, nil, transaction)
 


### PR DESCRIPTION
Prior to this commit, the method used to generate an
appropriate endpoint URL (dev mode sandbox, or prod) for calls to the
Invoiced REST API was not exposed to applications using this library.

Because there are cases where consumers of this libary need to use the
REST API directly (in order to get a plan by ID for instance), the
application is required to track the appropriate endpoint URLs
themselves.

This commit is composed of a change to make the makeEndPointURL visible
to the library consumer (as MakeEndPointURL) and propagates that change
to the places in this code base where the method was used.

Closes #11