### PR TITLE
Add ShipTo field to Subscription struct

### DIFF
--- a/invdendpoint/subscriptions.go
+++ b/invdendpoint/subscriptions.go
@@ -24,6 +24,16 @@ type Subscription struct {
 	Url         string                 `json:"url,omitempty"`          //URL to manage the subscription in the billing portal
 	CreatedAt   int64                  `json:"created_at,omitempty"`   //Timestamp when created
 	MetaData    map[string]interface{} `json:"metadata,omitempty"`     //A hash of key/value pairs that can store additional information about this object.
+	ShipTo      struct {
+		Address1    string `json:"address1,omitempty"`
+		Address2    string `json:"address2,omitempty"`
+		AttentionTo string `json:"attention_to,omitempty"`
+		City        string `json:"city,omitempty"`
+		Country     string `json:"country,omitempty"`
+		Name        string `json:"name,omitempty"`
+		PostalCode  string `json:"postal_code,omitempty"`
+		State       string `json:"state,omitempty"`
+	} `json:"ship_to,omitempty"` // Shipping address
 }
 
 func (s *Subscription) String() string {

--- a/invdendpoint/subscriptions.go
+++ b/invdendpoint/subscriptions.go
@@ -24,6 +24,8 @@ type Subscription struct {
 	Url         string                 `json:"url,omitempty"`          //URL to manage the subscription in the billing portal
 	CreatedAt   int64                  `json:"created_at,omitempty"`   //Timestamp when created
 	MetaData    map[string]interface{} `json:"metadata,omitempty"`     //A hash of key/value pairs that can store additional information about this object.
+	Prorate bool `json:"prorate,omitempty"`
+	ContractRenewalMode string `json:"contract_renewal_mode,omitempty"`
 	ShipTo      struct {
 		Address1    string `json:"address1,omitempty"`
 		Address2    string `json:"address2,omitempty"`

--- a/invdendpoint/subscriptions_test.go
+++ b/invdendpoint/subscriptions_test.go
@@ -42,7 +42,17 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
     "taxes": [],
     "url": "https://dundermifflin.invoiced.com/subscriptions/o2mAd2wWVfYy16XZto7xHwXX",
     "created_at": 1420391704,
-    "metadata": {}
+    "metadata": {},
+    "ship_to": {
+        "address1": "123 Main St",
+        "address2": "Ste 100",
+        "attention_to": "Regina Smith",
+        "city": "Austin",
+        "country": "US",
+        "name": "Company Name",
+        "postal_code": "78730",
+        "state": "TX"
+    }
 }`
 
 	so := new(Subscription)
@@ -108,7 +118,37 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
 
 	if so.CreatedAt != 1420391704 {
 		t.Fatal("Subscription CreatedAt is incorrect")
-
 	}
 
+	if so.ShipTo.Address1 != "123 Main St" {
+		t.Fatal("Subscription ShipTo.Address1 is incorrect")
+	}
+
+	if so.ShipTo.Address2 != "Ste 100" {
+		t.Fatal("Subscription ShipTo.Address2 is incorrect")
+	}
+
+	if so.ShipTo.AttentionTo != "Regina Smith" {
+		t.Fatal("Subscription ShipTo.AttentionTo is incorrect")
+	}
+
+	if so.ShipTo.City != "Austin" {
+		t.Fatal("Subscription ShipTo.City is incorrect")
+	}
+
+	if so.ShipTo.Country != "US" {
+		t.Fatal("Subscription ShipTo.Country is incorrect")
+	}
+
+	if so.ShipTo.Name != "Company Name" {
+		t.Fatal("Subscription ShipTo.Name is incorrect")
+	}
+
+	if so.ShipTo.PostalCode != "78730" {
+		t.Fatal("Subscription ShipTo.PostalCode is incorrect")
+	}
+
+	if so.ShipTo.State !=  "TX" {
+		t.Fatal("Subscription ShipTo.State is incorrect")
+	}
 }

--- a/invdendpoint/subscriptions_test.go
+++ b/invdendpoint/subscriptions_test.go
@@ -43,6 +43,8 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
     "url": "https://dundermifflin.invoiced.com/subscriptions/o2mAd2wWVfYy16XZto7xHwXX",
     "created_at": 1420391704,
     "metadata": {},
+    "prorate": true,
+    "contract_renewal_mode": "manual",
     "ship_to": {
         "address1": "123 Main St",
         "address2": "Ste 100",
@@ -115,6 +117,15 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
 		t.Fatal("Url is incorrect")
 
 	}
+
+	if so.Prorate != true {
+		t.Fatal("Subscription has incorrect Prorate status")
+	}
+
+	if so.ContractRenewalMode != "manual" {
+		t.Fatal("Subscription Ahas incorrect ContractRenewalMode status")
+	}
+
 
 	if so.CreatedAt != 1420391704 {
 		t.Fatal("Subscription CreatedAt is incorrect")


### PR DESCRIPTION
Prior to this commit, if a user wanted to add a shipping address to a
subscription, they were required to make a PATCH or POST request
direclty to the Invoiced REST API.

This can cause issues because creating and updating subscriptions with shipping
addresses requires logic for that field alone to be separate from the
rest of the subscription handling, i.e. more code to maintain and more
places for things to fail.

Thanks for taking a look!