### PR TITLE
Fix unmarshal errors

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -171,18 +171,6 @@ func addIncludeToEndPoint(endpoint string, includeValue string) string {
 
 }
 
-func addExpandToEndPoint(endpoint string, expandedValues *invdendpoint.Expand) string {
-	finalEndpoint := ""
-	if strings.Contains(endpoint, "?") {
-		finalEndpoint = endpoint + "&" + "expand=" + expandedValues.String()
-	} else {
-		finalEndpoint = endpoint + "?" + "expand=" + expandedValues.String()
-	}
-
-	return finalEndpoint
-
-}
-
 func makeEndPointSingular(endpoint string, id int64) string {
 	return endpoint + "/" + strconv.FormatInt(id, 10)
 }

--- a/connector_test.go
+++ b/connector_test.go
@@ -127,3 +127,14 @@ func TestMakeEndPointSingular(t *testing.T) {
 		t.Fatal("Expect =>", singularEndPoint, " Got =>", correctSingularEndPoint)
 	}
 }
+
+func TestAddIncludeToEndPoint(t *testing.T) {
+	endPoint := "https://www.do.com"
+	includeValue := "value"
+	expected := endPoint + "?" + "include=" + includeValue
+	result := addIncludeToEndPoint(endPoint, includeValue)
+
+	if expected != result {
+		t.Fatal("Expect =>", expected, " Got =>", result)
+	}
+}

--- a/invdendpoint/catalogitem.go
+++ b/invdendpoint/catalogitem.go
@@ -10,7 +10,7 @@ type CatalogItem struct {
 	UnitCost     float64                `json:"unit_cost,omitempty"`    //First address line
 	Description  string                 `json:"description,omitempty"`  //Optional description
 	Type         string                 `json:"service,omitempty"`      //Optional line item type. Used to group line items by type in reporting
-	Taxes        []Tax                  `json:"taxes,omitempty"`        //Collection of Tax Rate Objects
+	Taxes        []Rate                 `json:"taxes,omitempty"`        //Collection of Tax Rate Objects
 	Discountable bool                   `json:"discountable,omitempty"` //Excludes amount from discounts when false
 	Taxable      bool                   `json:"taxable,omitempty"`      //Excludes amount from taxes when false
 	CreatedAt    int64                  `json:"created_at,omitempty"`   //Timestamp when created

--- a/invdendpoint/lineitems.go
+++ b/invdendpoint/lineitems.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 type LineItem struct {
 	Id           int64                  `json:"id,omitempty"`           //The line item’s unique ID
-	CatalogItem  CatalogItem            `json:"catalog_item,omitempty"` //Optional Catalog Item ID. Fills the line item with the name and pricing of the Catalog Item.
+	CatalogItem  string                 `json:"catalog_item,omitempty"` //Optional Catalog Item ID. Fills the line item with the name and pricing of the Catalog Item.
 	Type         string                 `json:"type,omitempty"`         //Optional line item type. Used to group line items by type in reporting
 	Name         string                 `json:"name,omitempty"`         //Title
 	Description  string                 `json:"description,omitempty"`  //Optional description

--- a/invdendpoint/lineitems_test.go
+++ b/invdendpoint/lineitems_test.go
@@ -6,35 +6,38 @@ import (
 )
 
 func TestUnMarshalLineItemObject(t *testing.T) {
+
+	catalogItem := `{
+		"id": "delivery",
+		"object": "catalog_item",
+		"name": "Delivery",
+		"currency": "usd",
+		"unit_cost": 100,
+		"description": null,
+		"type": "service",
+		"taxes": [],
+		"discountable": true,
+		"taxable": true,
+		"unit_cost": 10,
+		"created_at": 1477327516,
+		"metadata": {}
+	  }`
+
 	s := `{
-  "id": 8,
-  "catalog_item": {
-  "id": "delivery",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
-  "type": "service",
-  "name": "Delivery",
-  "description": "",
-  "quantity": 1,
-  "unit_cost": 10,
-  "amount": 10,
-  "discountable": true,
-  "discounts": [],
-  "taxable": true,
-  "taxes": [],
-  "metadata": {}
-}`
+		"id": 8,
+		"catalog_item": `+ catalogItem + `,
+		"type": "service",
+		"name": "Delivery",
+		"description": "",
+		"quantity": 1,
+		"unit_cost": 10,
+		"amount": 10,
+		"discountable": true,
+		"discounts": [],
+		"taxable": true,
+		"taxes": [],
+		"metadata": {}
+	}`
 
 	so := new(LineItem)
 
@@ -72,7 +75,7 @@ func TestUnMarshalLineItemObject(t *testing.T) {
 		t.Fatal("Item 1 has incorrect taxable")
 	}
 
-	if so.CatalogItem.Id != "delivery" {
+	if so.CatalogItem != catalogItem {
 		t.Fatal("Item 1 has incorrect catalogitem id")
 	}
 

--- a/invdendpoint/subscriptionaddons.go
+++ b/invdendpoint/subscriptionaddons.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 type SubscriptionAddon struct {
 	Id          int64       `json:"id,omitempty"`           //The subscription’s unique ID
-	CatalogItem CatalogItem `json:"catalog_item,omitempty"` //Catalog Item ID
+	CatalogItem string      `json:"catalog_item,omitempty"` //Catalog Item ID
 	Plan        string      `json:"plan,omitempty"`         //The Subscription's Plan ID
 	Quantity    int64       `json:"quantity,omitempty"`     //Quantity
 	CreatedAt   int64       `json:"created_at,omitempty"`   //Timestamp when created

--- a/invdendpoint/subscriptionaddons_test.go
+++ b/invdendpoint/subscriptionaddons_test.go
@@ -5,24 +5,27 @@ import (
 	"testing"
 )
 
+
 func TestUnMarshalSubscriptionAddonObject(t *testing.T) {
-	s := `{
+  catalogItem := `{
+    "id": "delivery",
+    "object": "catalog_item",
+    "name": "Delivery",
+    "currency": "usd",
+    "unit_cost": 100,
+    "description": null,
+    "type": "service",
+    "taxes": [],
+    "discountable": true,
+    "taxable": true,
+    "unit_cost": 10,
+    "created_at": 1477327516,
+    "metadata": {}
+    }`
+
+  s := `{
     "id": 3,
-    "catalog_item": {
-  "id": "delivery",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+    "catalog_item":` + catalogItem + `,
     "plan" : "test-plan",
     "quantity": 11,
     "created_at": 1420391704

--- a/invdendpoint/subscriptions.go
+++ b/invdendpoint/subscriptions.go
@@ -20,7 +20,7 @@ type Subscription struct {
 	Status      string                 `json:"status,omitempty"`       //Subscription status, one of not_started, active, past_due, finished
 	Addons      []SubscriptionAddon    `json:"addons,omitempty"`       //Collection of Subscription Addons
 	Discounts   []Discount             `json:"discount,omitempty"`     //Collection of Coupon IDs
-	Taxes       []Tax                  `json:"taxes,omitempty"`        //Collection of Tax Rate IDs
+	Taxes       []Rate                 `json:"taxes,omitempty"`        //Collection of Tax Rate IDs
 	Url         string                 `json:"url,omitempty"`          //URL to manage the subscription in the billing portal
 	CreatedAt   int64                  `json:"created_at,omitempty"`   //Timestamp when created
 	MetaData    map[string]interface{} `json:"metadata,omitempty"`     //A hash of key/value pairs that can store additional information about this object.

--- a/invdendpoint/subscriptions_test.go
+++ b/invdendpoint/subscriptions_test.go
@@ -6,6 +6,22 @@ import (
 )
 
 func TestUnMarshalSubscriptionObject(t *testing.T) {
+	catalogItem := `{
+		"id": "ipad-license",
+		"object": "catalog_item",
+		"name": "Delivery",
+		"currency": "usd",
+		"unit_cost": 100,
+		"description": null,
+		"type": "service",
+		"taxes": [],
+		"discountable": true,
+		"taxable": true,
+		"unit_cost": 10,
+		"created_at": 1477327516,
+		"metadata": {}
+	  }`
+
 	s := `{
     "id": 595,
     "customer": 15444,
@@ -19,21 +35,7 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
     "addons": [
         {
             "id": 3,
-            "catalog_item": {
-  "id": "ipad-license",
-  "object": "catalog_item",
-  "name": "Delivery",
-  "currency": "usd",
-  "unit_cost": 100,
-  "description": null,
-  "type": "service",
-  "taxes": [],
-  "discountable": true,
-  "taxable": true,
-  "unit_cost": 10,
-  "created_at": 1477327516,
-  "metadata": {}
-},
+            "catalog_item": ` + catalogItem + `,
             "quantity": 11,
             "created_at": 1420391704
         }
@@ -101,8 +103,8 @@ func TestUnMarshalSubscriptionObject(t *testing.T) {
 		t.Fatal("Subscription Addon 0 has incorrect status")
 	}
 
-	if so.Addons[0].CatalogItem.Id != "ipad-license" {
-		t.Fatal("Subscription Addon CatalogItem 0  has incorrect status")
+	if so.Addons[0].CatalogItem != catalogItem {
+		t.Fatal("Subscription Addon 0 CatalogItem has incorrect payload")
 	}
 
 	if so.Addons[0].Quantity != 11 {

--- a/invdendpoint/taxes.go
+++ b/invdendpoint/taxes.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 //Represents the application of tax to an invoice or line item.
 type Tax struct {
-	Id      int64   `json:"id,omitempty"`       //The tax’s unique ID
+	Id      int64   `json:"id,string,omitempty"`       //The tax’s unique ID
 	Amount  float64 `json:"amount,omitempty"`   //Tax amount
 	TaxRate Rate    `json:"tax_rate,omitempty"` //Tax Rate the tax was computed from, if any
 }

--- a/invdendpoint/taxes.go
+++ b/invdendpoint/taxes.go
@@ -2,7 +2,7 @@ package invdendpoint
 
 //Represents the application of tax to an invoice or line item.
 type Tax struct {
-	Id      int64   `json:"id,string,omitempty"`       //The tax’s unique ID
+	Id      int64   `json:"id,omitempty"`       //The tax’s unique ID
 	Amount  float64 `json:"amount,omitempty"`   //Tax amount
 	TaxRate Rate    `json:"tax_rate,omitempty"` //Tax Rate the tax was computed from, if any
 }

--- a/invoice.go
+++ b/invoice.go
@@ -5,7 +5,6 @@ import (
 	"github.com/Invoiced/invoiced-go/invdendpoint"
 )
 
-const defaultExpandInvoice = "items.catalog_item"
 
 type Invoice struct {
 	*Connection
@@ -85,12 +84,6 @@ func (c *Invoice) Retrieve(id int64) (*Invoice, error) {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
 	}
 
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandInvoice)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
-
 	custEndPoint := new(invdendpoint.Invoice)
 
 	invoice := &Invoice{c.Connection, custEndPoint, c.IncludeUpdatedAt}
@@ -112,12 +105,6 @@ func (c *Invoice) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) 
 	if c.IncludeUpdatedAt {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
 	}
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandInvoice)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	invoices := make(Invoices, 0)
 
@@ -151,12 +138,6 @@ func (c *Invoice) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (In
 	if c.IncludeUpdatedAt {
 		endPoint = addIncludeToEndPoint(endPoint, "updated_at")
 	}
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandInvoice)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	invoices := make(Invoices, 0)
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -4,8 +4,6 @@ import (
 	"github.com/Invoiced/invoiced-go/invdendpoint"
 )
 
-const defaultExpandSubscription = "addons.catalog_item"
-
 type Subscription struct {
 	*Connection
 	*invdendpoint.Subscription
@@ -79,12 +77,6 @@ func (c *Subscription) Save() error {
 func (c *Subscription) Retrieve(id int64) (*Subscription, error) {
 	endPoint := makeEndPointSingular(c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint), id)
 
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandSubscription)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
-
 	custEndPoint := new(invdendpoint.Subscription)
 
 	subscription := &Subscription{c.Connection, custEndPoint}
@@ -102,12 +94,6 @@ func (c *Subscription) Retrieve(id int64) (*Subscription, error) {
 func (c *Subscription) ListAll(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Subscriptions, error) {
 	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandSubscription)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	subscriptions := make(Subscriptions, 0)
 
@@ -138,12 +124,6 @@ NEXT:
 func (c *Subscription) List(filter *invdendpoint.Filter, sort *invdendpoint.Sort) (Subscriptions, string, error) {
 	endPoint := c.MakeEndPointURL(invdendpoint.SubscriptionsEndPoint)
 	endPoint = addFilterSortToEndPoint(endPoint, filter, sort)
-
-	expandedValues := invdendpoint.NewExpand()
-
-	expandedValues.Set(defaultExpandSubscription)
-
-	endPoint = addExpandToEndPoint(endPoint, expandedValues)
 
 	subscriptions := make(Subscriptions, 0)
 


### PR DESCRIPTION
## Mitigate error unmarshalling Tax.id 

We've run into cases where our request for a subscription
(Subscription.Retrieve) failed with the following message:

`json: cannot unmarshal string into Go struct field Tax.id of type
int64`

Looking into the docs on json.Marshal here
(https://golang.org/pkg/encoding/json/#Marshal) it says that:

> The "string" option signals that a field is stored as JSON inside a JSON-encoded string. It applies only to fields of string, floating point, integer, or boolean types. This extra level of encoding is sometimes used when communicating with JavaScript programs

My hypothesis is that _this_ int64 is different than the others becasue
of how it's used with Avalara? Or another JavaScript program?

Up for suggestions here if there's a preference for an alternative
solution but it seemed to have done the trick for us on our fork.

## Address unmarshal catalog_item errors

Solution as discussed with @splimby. I've been running into the error:
`json: cannot unmarshal string into Go struct field LineItem.catalog_item of type invdendpoint.CatalogItem`
when deleting invoices.

In addition to revising the CatalogItem field's use to a string rather
than a CatalogItem object, this commit revises tests to handle new type
signature, removes other library logic that made assumptions about the
structure of the revised CatalogItem fields, and removes an unused
funtion left over after the previously mentioned library logic removal.

Removing the unused function was done because of a failure its presence
caused when running `golangci-lint run`.