### PR TITLE
Add CalculateTaxes field to Invoice object

### DIFF
--- a/invdendpoint/invoices.go
+++ b/invdendpoint/invoices.go
@@ -49,6 +49,8 @@ type Invoice struct {
 	CreatedAt  int64                  `json:"created_at,omitempty"`  //Timestamp when created
 	MetaData   map[string]interface{} `json:"metadata,omitempty"`    //A hash of key/value pairs that can store additional information about this object.
 
+	CalculateTaxes bool `json:"calculate_taxes,omitempty"` // Flag to indicate whether taxes should be calculated on the invoice
+
 	// add disabled payment methods
 }
 

--- a/invdendpoint/invoices_test.go
+++ b/invdendpoint/invoices_test.go
@@ -88,7 +88,8 @@ func TestUnMarshalInvoiceObject(t *testing.T) {
   "payment_url": "https://dundermifflin.invoiced.com/invoices/IZmXbVOPyvfD3GPBmyd6FwXY/payment",
   "pdf_url": "https://dundermifflin.invoiced.com/invoices/IZmXbVOPyvfD3GPBmyd6FwXY/pdf",
   "created_at": 1415229884,
-  "metadata": {}
+  "metadata": {},
+  "calculate_taxes": true
 }`
 
 	so := new(Invoice)
@@ -237,6 +238,10 @@ func TestUnMarshalInvoiceObject(t *testing.T) {
 
 	if so.CreatedAt != 1415229884 {
 		t.Fatal("CreatedAt is incorrect")
+	}
+
+	if so.CalculateTaxes != true {
+		t.Fatal("CalculateTaxes flag is incorrect")
 	}
 
 }


### PR DESCRIPTION
The API's invoice object has a field to toggle a 'calculate_taxes'
field. This commit exposes that field to the Go library user.